### PR TITLE
Remove correct transient location when deactivating

### DIFF
--- a/magit-circleci.el
+++ b/magit-circleci.el
@@ -230,7 +230,7 @@ BUILD is the build object."
 (defun magit-circleci--deactivate ()
   "Remove the circleci section and the transient."
   (remove-hook 'magit-status-sections-hook #'magit-circleci--section)
-  (transient-remove-suffix 'magit-dispatch "%"))
+  (transient-remove-suffix 'magit-dispatch "\""))
 
 ;;;###autoload
 (define-minor-mode magit-circleci-mode


### PR DESCRIPTION
When calling magit-circleci-mode twice, it calls deactivate which removes the wrong magit transient location suffix which makes it crash when trying to insert circleci suffix at the just removed location.